### PR TITLE
suppress warnings from 3rd party code

### DIFF
--- a/source/suppress-warnings.cmake
+++ b/source/suppress-warnings.cmake
@@ -14,6 +14,8 @@
 
 message("suppressing warnings from mbed-hal-st-stm32cubef4")
 
-set_target_properties(mbed-hal-st-stm32cubef4
-    PROPERTIES COMPILE_FLAGS "-Wno-sign-compare -Wno-unused-variable -Wno-unused-parameter"
-)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set_target_properties(mbed-hal-st-stm32cubef4
+        PROPERTIES COMPILE_FLAGS "-Wno-sign-compare -Wno-unused-variable -Wno-unused-parameter"
+    )
+endif()


### PR DESCRIPTION
@meriac @bremoran @bogdanm @0xc0170: here's an example of setting specific compilation flags for a library, so that Milosch and Brendan don't go crazy and Nerf us all :sweat_smile: 

If you let me know which other modules need this, I can do it there too
